### PR TITLE
Fix: Feature calculation infinite loop

### DIFF
--- a/src/lib/src/pbox/core/executable/parsers/__common__.py
+++ b/src/lib/src/pbox/core/executable/parsers/__common__.py
@@ -229,7 +229,7 @@ class AbstractParsedExecutable(ABC, CustomReprMixin, GetItemMixin):
                 string_table_offset = pe.header.pointerto_symbol_table + pe.header.numberof_symbols * 18
                 fh.seek(string_table_offset + int(name[1:]))
                 # read the null-terminated string from the file
-                return b"".join(iter(lambda: fh.read(1), b'\x00')).decode("utf-8", errors="ignore")
+                return b"".join(iter(lambda: (b := fh.read(1)) and b != b'' and b or b'\x00', b'\x00')).decode("utf-8", errors="ignore")
             # start parsing section names
             names = [ensure_str(s.name) for s in self]
             from re import match


### PR DESCRIPTION
Fix for #185 

Feature calculation may fall into an infinite loop when the file contains a malformed or truncated string tables.
The _decode function (pbox/core/executable/parsers/__common__.py) could loop infinitely because iter() only stops on null bytes, not on EOF.

The _decode function uses (line 232):
```python
return b"".join(iter(lambda: fh.read(1), b'\x00')).decode("utf-8", errors="ignore")
```
This only stops when reading a null byte (\x00). However, if the string table is truncated or malformed (no null terminator before EOF), fh.read(1) returns b'' indefinitely at EOF, which never matches b'\x00'.

Proposed fix :
```python
return b"".join(iter(lambda: (b := fh.read(1)) and b != b'' and b or b'\x00', b'\x00')).decode("utf-8", errors="ignore")
```



