### PR TITLE
Adding taxonomy profile generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,12 +164,12 @@ RUN sudo mkdir -p /mnt/share \
 # copy executable format related data
 COPY --chown=$USER src/data $PBWS/data
 # install LLM-related dependencies before pbox so they benefit from a separate cache layer
-RUN pip3 install --user --no-warn-script-location --break-system-packages \
+RUN /home/user/.opt/venv/bin/pip install --no-warn-script-location \
     llama-cpp-python huggingface_hub
 # copy and install pbox (main library for tools) and pboxtools (lightweight library for items)
 COPY --chown=$USER src/lib /tmp/lib
 RUN chmod -R u+w /tmp/lib \
- && pip3 install --user --no-warn-script-location --break-system-packages /tmp/lib/ \
+ && pip3 install --no-warn-script-location /tmp/lib/ \
  && rm -rf /tmp/lib
 COPY --chown=$USER $FILES/tools/packing-box $PBOX
 # install analyzers

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,12 +164,12 @@ RUN sudo mkdir -p /mnt/share \
 # copy executable format related data
 COPY --chown=$USER src/data $PBWS/data
 # install LLM-related dependencies before pbox so they benefit from a separate cache layer
-RUN /home/user/.opt/venv/bin/pip install --no-warn-script-location \
+RUN pip3 install --user --no-warn-script-location --break-system-packages \
     llama-cpp-python huggingface_hub
 # copy and install pbox (main library for tools) and pboxtools (lightweight library for items)
 COPY --chown=$USER src/lib /tmp/lib
 RUN chmod -R u+w /tmp/lib \
- && pip3 install --no-warn-script-location /tmp/lib/ \
+ && pip3 install --user --no-warn-script-location --break-system-packages /tmp/lib/ \
  && rm -rf /tmp/lib
 COPY --chown=$USER $FILES/tools/packing-box $PBOX
 # install analyzers

--- a/src/lib/src/pbox/core/model/__init__.py
+++ b/src/lib/src/pbox/core/model/__init__.py
@@ -16,6 +16,7 @@ from ..executable import *
 from ..pipeline import *
 from ...helpers import *
 from ..items.detector import Detector
+from collections import defaultdict
 
 lazy_load_module("joblib")
 
@@ -530,11 +531,24 @@ class Model(BaseModel):
                f"{len(significant)}/{len(ranked)} features above]:")
         for name, imp in significant:
             l.info(f"  {name}: {imp:.4f}")
+        registry = Features.registry.get('PE32', Features.registry.get('PE', {}))
+        category_map = {}
+        for feature_name, feature in registry.items():
+            category_map[feature_name] = feature.get('category', 'unknown')
+        category_shap = defaultdict(float)
+        for name, imp in significant:
+            category_shap[category_map.get(name, 'unknown')] += imp
+        total = sum(category_shap.values()) or 1.0
+        category_profile = {category: value / total for category, value in sorted(category_shap.items(), key=lambda x: -x[1])}
+        l.info(f"Category profile (normalized):")
+        for category, percentage in category_profile.items():
+            l.info(f"  {category}: {percentage:.1%}")
+        self._explanation['category_profile'] = category_profile
         if not export and plots is None:
             return self._explanation
         from .explain import _EXPLANATIONS
         display = max_display if max_display != 10 else n_significant
-        for p in (["summary"] if plots is None else list(_EXPLANATIONS.keys()) if "all" in plots else plots):
+        for p in (["summary", "taxonomy"] if plots is None else list(_EXPLANATIONS.keys()) if "all" in plots else plots):
             # when a sample index is provided, generate a single plot instead of the packed/not-packed pair
             if sample_idx is not None and p in ("force", "waterfall"):
                 plot_func = _EXPLANATIONS.get(f"{p}_packed") 
@@ -554,6 +568,19 @@ class Model(BaseModel):
                     plot_func(self, feature_idx=feature_idx)
                 else:
                     plot_func(self, max_display=display)
+        if self._explanation.get('category_profile'):
+            try:
+                profile_path = config['experiment'].joinpath("taxonomy", f"{self.name}_taxonomy-profile.json")
+                profile_path.dirname.mkdir(exist_ok=True, parents=True)
+            except KeyError:
+                profile_path = Path(f"{self.name}_taxonomy-profile.json")
+            with open(str(profile_path), 'w') as f:
+                json.dump({
+                    'model': self.name,
+                    'surrogate': self._metadata.get('surrogate'),
+                    'profile': self._explanation['category_profile']
+                }, f, indent=2)
+            l.info(f"Saved taxonomy profile to {profile_path}")
         return self._explanation
     
     RESET  = "\033[0m"

--- a/src/lib/src/pbox/core/model/explain.py
+++ b/src/lib/src/pbox/core/model/explain.py
@@ -23,11 +23,16 @@ def _get_explainer(model_wrapper, X_background, **kw):
                    "AdaBoostClassifier"}
     linear_models = {"LogisticRegression", "SGDClassifier", "RidgeClassifier", "Perceptron"}
     if (clf_name := inner_clf.__class__.__name__) in tree_models:
-        l.debug(f"Using TreeExplainer for {clf_name}")
+        l.info(f"Using TreeExplainer for {clf_name}")
         return shap.TreeExplainer(inner_clf)
     if clf_name in linear_models:
-        l.debug(f"Using LinearExplainer for {clf_name}")
-        return shap.LinearExplainer(inner_clf, X_background)
+        l.info(f"Using LinearExplainer for {clf_name}")
+        if hasattr(predictor, 'steps') and len(predictor.steps) > 1:
+            X_scaled = X_background.copy()
+            for name, step in predictor.steps[:-1]:
+                X_scaled = step.transform(X_scaled)
+            return shap.LinearExplainer(inner_clf, X_scaled), predictor.steps[:-1]
+        return shap.LinearExplainer(inner_clf, X_background), None
     # for everything else (SVC, MLP, ...), use Kernel -> slower
     l.warning(f"Using KernelExplainer for {clf_name}")
     # reduce background for Kernel speed
@@ -100,20 +105,30 @@ def explain_model(model_wrapper, X_data, feature_names=None, max_samples=None, s
             X_subset = X_data.iloc[indices] if hasattr(X_data, 'iloc') else X_data[indices]
         else:
             X_subset = X_data
-    explainer = _get_explainer(model_wrapper, X_data, logger=l)
+    result = _get_explainer(model_wrapper, X_data, logger=l)
+    if isinstance(result, tuple):
+        explainer, preprocess_steps = result
+    else:
+        explainer, preprocess_steps = result, None
+    X_explain = X_subset
+    if preprocess_steps is not None:
+        X_explain = X_subset.copy()
+        for name, step in preprocess_steps:
+            X_explain = step.transform(X_explain)
     # compute SHAP values ONLY on the subset
     if isinstance(explainer, shap.KernelExplainer):
         nsamples = kw.get('nsamples', config['shap-values-number-samples']) # rule of thumb = 2*n_features + 2048
         l.info(f"Computing KernelSHAP on {len(X_subset)} samples with nsamples={nsamples}")
-        shap_values = explainer.shap_values(X_subset, nsamples=nsamples)
+        shap_values = explainer.shap_values(X_explain, nsamples=nsamples)
     else:
-        shap_values = explainer.shap_values(X_subset)
-    # for tree explainer, shape_value = [array_classe_0, array_classe_1] so we just take value for class 1
+        shap_values = explainer.shap_values(X_explain)
+    # for tree explainer, shap_value = [array_classe_0, array_classe_1] so we just take value for class 1
     if isinstance(shap_values, list):
         shap_values = shap_values[1]
     # for kernel explainer, shape_value = (n_samples, n_features) 
     elif hasattr(shap_values, 'shape') and shap_values.ndim == 3:
         shap_values = shap_values[:, :, 1]
+    shap_values = np.array(shap_values, dtype=np.float64)
     expected = explainer.expected_value
     if isinstance(expected, (list, np.ndarray)) and len(expected) == 2:
         expected = expected[1]
@@ -135,7 +150,7 @@ def explain_model(model_wrapper, X_data, feature_names=None, max_samples=None, s
 
 
 @save_figure
-def shap_decision(model, max_samples=50, **kw):
+def shap_decision(model, max_display=10, max_samples=50, **kw):
     plt.figure(figsize=(14, 10))
     exp = model._explanation
     n = min(max_samples, len(exp['shap_values']))
@@ -156,8 +171,9 @@ def shap_decision(model, max_samples=50, **kw):
 
 @save_figure
 def shap_heatmap(model, max_display=10, **kw):
+    exp = model._explanation
     plt.figure(figsize=(14, 10))
-    shap.plots.heatmap(model._explanation['shap_explanation'], max_display=max_display, show=False)
+    shap.plots.heatmap(exp['shap_explanation'], max_display=max_display, show=False)
     plt.tight_layout()
     return f"{model.basename}/explained_shap-heatmap"
 
@@ -197,6 +213,36 @@ def shap_force_not_packed(model, sample_idx=None, **kw):
     _local_plot(model, packed=False, sample_idx=sample_idx, plot_type="force", **kw)
     return f"{model.basename}/explained_shap-force-not-packed"
 
+@save_figure
+def shap_taxonomy_donut(model, **kw):
+    exp = model._explanation
+    profile = exp.get('category_profile', {})
+    if not profile:
+        return None
+    
+    cats = list(profile.keys())
+    vals = list(profile.values())
+    
+    filtered = [(c, v) for c, v in zip(cats, vals) if v >= 0.02]
+    other = sum(v for _, v in zip(cats, vals) if v < 0.02)
+    if other > 0:
+        filtered.append(('Other', other))
+    cats_f, vals_f = zip(*filtered)
+    
+    colors = ['#264653', '#2a9d8f', '#e9c46a', '#f4a261',
+              '#e76f51', '#606c38', '#dda15e', '#bc6c25', '#023047']
+    
+    fig, ax = plt.subplots(figsize=(8, 8))
+    wedges, texts, autotexts = ax.pie(
+        vals_f, labels=cats_f, autopct='%1.0f%%',
+        colors=colors[:len(vals_f)], pctdistance=0.8,
+        wedgeprops=dict(width=0.4, edgecolor='white', linewidth=2))
+    for t in autotexts:
+        t.set_fontsize(9)
+        t.set_fontweight('bold')
+    ax.set_title(f'Model taxonomy of {model.basename}', size=13, fontweight='bold')
+    plt.tight_layout()
+    return f"{model.basename}/explained_shap-taxonomy"
 
 _EXPLANATIONS = {
     'decision':             shap_decision,
@@ -204,6 +250,7 @@ _EXPLANATIONS = {
     'force_packed':         shap_force_packed,
     'heatmap':              shap_heatmap,
     'summary':              shap_summary,
+    'taxonomy':             shap_taxonomy_donut,
     'waterfall_not_packed': shap_waterfall_not_packed,
     'waterfall_packed':     shap_waterfall_packed,
 }

--- a/src/lib/src/pbox/core/model/fuzz.py
+++ b/src/lib/src/pbox/core/model/fuzz.py
@@ -3,6 +3,9 @@ import matplotlib
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 import re
+import numpy as np
+import pandas as pd
+from pathlib import Path
 
 from ...helpers import *
 
@@ -215,7 +218,7 @@ def plot_bootstrap_ci(model, ci_result, **kw):
     ax.axvline(0, color='k', lw=0.5)
     ax.set_title(f'Feature Importance with 95% CI (Top {top_n})', fontsize=14, fontweight='bold')
     plt.tight_layout()
-    return f"{model.basename}_fuzz-bootstrap-ci"
+    return f"{model.basename}/fuzz-bootstrap-ci"
 
 
 @save_figure
@@ -238,7 +241,7 @@ def plot_bump_chart(model, stability_result, **kw):
     ax.set_ylim(top_n + 1, 0)
     ax.legend(bbox_to_anchor=(1.02, 1), loc='upper left', fontsize=8)
     plt.tight_layout()
-    return f"{model.basename}_fuzz-bump-chart"
+    return f"{model.basename}/fuzz-bump-chart"
 
 
 @save_figure
@@ -291,7 +294,7 @@ def plot_fuzz_impact(model, fuzz_result, feature_name, delta_pct, **kw):
         ax3.legend()
         plt.suptitle(f'Fuzzing: {feature_name} (δ={ds})', fontsize=14, fontweight='bold')
     plt.tight_layout()
-    return f"{model.basename}_fuzz-impact_{feature_name}"
+    return f"{model.basename}/fuzz-impact_{feature_name}"
 
 
 @save_figure
@@ -314,7 +317,7 @@ def plot_fuzz_summary(model, fuzz_results, **kw):
     ax1.invert_yaxis()
     plt.suptitle(f'Feature Sensitivity (Top {top_n})', fontsize=14, fontweight='bold')
     plt.tight_layout()
-    return f"{model.basename}_fuzz-summary"
+    return f"{model.basename}/fuzz-summary"
 
 
 @save_figure
@@ -341,7 +344,7 @@ def plot_interaction_heatmap(model, matrix, labels, diag, **kw):
     plt.colorbar(im, ax=ax, shrink=0.8, label='Interaction strength')
     ax.set_title('Pairwise Feature Interactions\n(diagonal = individual)', fontsize=14, fontweight='bold')
     plt.tight_layout()
-    return f"{model.basename}_fuzz-interactions"
+    return f"{model.basename}/fuzz-interactions"
 
 
 def run_interaction_analysis(model, data, feature_names, fuzz_results, top_k=10, delta_pct=0.1, logger=None):

--- a/src/lib/src/pbox/core/model/fuzz.py
+++ b/src/lib/src/pbox/core/model/fuzz.py
@@ -3,9 +3,6 @@ import matplotlib
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 import re
-import numpy as np
-import pandas as pd
-from pathlib import Path
 
 from ...helpers import *
 


### PR DESCRIPTION
This PR adds the display and generation of a taxonomy profile. 

- Based on the "category" tag of a feature set, the shap tool can generate normalized feature category importance. Those will be displayed in the CLI and saved as json in a experiment's folder called "taxonomy". 
- A bar plot is also generated
- Example of output : 
```
00:39:50.310 [INFO] Feature importance (SHAP) [threshold=0.0074, 13/354 features above]:
00:39:50.314 [INFO]   is_average_per_section_512B_block_entropy>6.5: 0.0829
00:39:50.314 [INFO]   is_import_functions_count<=14: 0.0483
00:39:50.314 [INFO]   is_average_per_section_512B_block_entropy>6.7: 0.0390
00:39:50.314 [INFO]   is_import_functions_count<=18: 0.0257
00:39:50.314 [INFO]   is_average_per_section_512B_block_entropy>6.6: 0.0248
00:39:50.314 [INFO]   average_512B_block_entropy: 0.0237
00:39:50.314 [INFO]   average_256B_block_entropy: 0.0202
00:39:50.314 [INFO]   is_import_functions_count<=13: 0.0166
00:39:50.314 [INFO]   is_import_functions_count<=15: 0.0103
00:39:50.315 [INFO]   is_average_per_section_256B_block_entropy>6.5: 0.0094
00:39:50.315 [INFO]   has_uninitialized_data: 0.0090
00:39:50.315 [INFO]   is_entropy_ep_section>7.8: 0.0087
00:39:50.315 [INFO]   is_entropy_ep_section>7.6: 0.0078
00:39:50.324 [INFO] Category profile (normalized):
00:39:50.324 [INFO]   entropy: 66.3%
00:39:50.324 [INFO]   functions: 30.9%
00:39:50.324 [INFO]   header: 2.8%
```
```json
{
  "model": "balanced-dataset_net-pe32-pe64_912_svm_f354_surr-Bintropy",
  "surrogate": "svm_Bintropy",
  "profile": {
    "entropy": 0.6632461908574654,
    "functions": 0.30904680405094903,
    "header": 0.027707005091585628
  }
}
```
- It also incorporate minor adjustments on the fuzz and explain modules 