### PR TITLE
Adding possibility to fuzz on a specific dataset or executable

### DIFF
--- a/src/files/tools/model
+++ b/src/files/tools/model
@@ -68,6 +68,7 @@ if __name__ == '__main__':
                       help="compute bootstrap confidence intervals on impact scores")
     fuzz.add_argument("--interactions", action="store_true",
                       help="compute pairwise feature interaction heatmap for top features")
+    fuzz.add_argument("executable", nargs="?", default=None, help="dataset or executable to explain on")
     edit = sparsers.add_parser("edit", category="create/modify/delete", help="edit the performance log file")
     add_argument(edit, "mdname", force=True)
     listm = sparsers.add_parser("list", category="read", help="list all the models from the workspace")

--- a/src/files/tools/model
+++ b/src/files/tools/model
@@ -68,7 +68,7 @@ if __name__ == '__main__':
                       help="compute bootstrap confidence intervals on impact scores")
     fuzz.add_argument("--interactions", action="store_true",
                       help="compute pairwise feature interaction heatmap for top features")
-    fuzz.add_argument("executable", nargs="?", default=None, help="dataset or executable to explain on")
+    fuzz.add_argument("executable", nargs="?", default=None, help="dataset or executable to fuzz")
     edit = sparsers.add_parser("edit", category="create/modify/delete", help="edit the performance log file")
     add_argument(edit, "mdname", force=True)
     listm = sparsers.add_parser("list", category="read", help="list all the models from the workspace")

--- a/src/lib/src/pbox/core/model/fuzz.py
+++ b/src/lib/src/pbox/core/model/fuzz.py
@@ -110,6 +110,10 @@ def compute_impact_per_class(fuzz_result):
 
 def fuzz_features(model, data, feature_names, delta_pct=0.1, top_n=20, export=True, output_dir="fuzz_plots",
                   use_stddev=False, n_sigma=1.0, logger=None):
+    if use_stddev and len(data) < 2:
+        if logger:
+            logger.warning("Std-based fuzzing requires multiple samples. Falling back to delta-based.")
+        use_stddev = False
     data = data[feature_names].apply(pd.to_numeric, errors='coerce').fillna(0).copy()
     predict_fn = _make_predict_proba_func(model)
     if export:


### PR DESCRIPTION
Small fix to be able to fuzz a specific dataset or executable.

Before : 
```bash
$ model fuzz balanced-train-1_net-pe32-pe64_780_rf_f6 balanced-train-1-fileless 
usage: model [-h] [--help] [-v] CMD ...
model: error: unrecognized arguments: balanced-train-1-fileless
```

After : 
```bash
$ model fuzz balanced-train-1_net-pe32-pe64_780_rf_f6 balanced-train-1-fileless --no-export
00:00:02.841 [INFO] Fuzzing dataset:  balanced-train-1-fileless
00:00:02.841 [INFO] Loading features...
00:00:03.794 [INFO] Starting fuzzing on balanced-train-1_net-pe32-pe64_780_rf_f6...
00:00:03.796 [INFO] Fuzzing 6 features with δ=10%...
00:00:03.878 [INFO] 0 features (0.0%) had <1% impact on predictions.

  Fuzzing Analysis: balanced-train-1_net-pe32-pe64_780_rf_f6
  Feature                      Packed +δ  Packed -δ  Not-packed +δ  Not-packed -δ
 ─────────────────────────────────────────────────────────────────────────────────
  ep_ratio                       -0.0477    +0.0326        -0.0014        +0.5485
  number_rw_sections             +0.0011    -0.0438        +0.2685        -0.0014
  is_ep_not_in_code_section      +0.0184    -0.0014        +0.1256        +0.0000
  entropy_code_section           +0.0107    -0.0143        +0.1191        +0.0129
  number_standard_sections       -0.0194    +0.0034        -0.0039        +0.0390
  entropy                        -0.0012    -0.0140        +0.0289        +0.0021
```

Note that if an executable is chosen and --stddev mode is used, the tool will automatically fall back on delta-based perturbation : 

```bash
$ model fuzz balanced-train-1_net-pe32-pe64_780_rf_f6 /mnt/share/dataset-packed-pe/packed/UPX/upx_accesschk.exe --stddev
00:00:01.034 [INFO] Fuzzing dataset:  /mnt/share/dataset-packed-pe/packed/UPX/upx_accesschk.exe
00:00:02.821 [INFO] Computing features...
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1/1 samples • 0:00:00 • 0:00:00
00:00:03.699 [INFO] Starting fuzzing on balanced-train-1_net-pe32-pe64_780_rf_f6...
00:00:03.701 [WARNING] Std-based fuzzing requires multiple samples. Falling back to delta-based.
00:00:03.704 [INFO] Fuzzing 6 features with δ=10%...
```