### PR TITLE
feature llm: few-shot and new algorithm registration

### DIFF
--- a/src/conf/algorithms.yml
+++ b/src/conf/algorithms.yml
@@ -194,7 +194,7 @@ LLM:
       - MM
   Mistral-LLM:
     base:        !!python/name:pbox.core.model.algorithm.llm.LLMClassifier
-    description: LLM-based packing classifier (llama-cpp-python)
+    description: LLM-based packing classifier (llama-cpp-python, zero-shot)
     multiclass:  false
     parameters:
       static:
@@ -207,8 +207,30 @@ LLM:
         n_ctx:        2048
         n_threads:    4
         max_tokens:   64
-      cv:
-        prompt_file: ['zero_shot_binary.txt', 'few_shot_binary.txt']
+        temperature:  0.0
+        prompt_file:  zero_shot_binary.txt
+        trace_outputs: false
+        trace_dir:    ~/.packing-box/cache/llm-traces
+  Mistral-LLM-FewShot:
+    base:        !!python/name:pbox.core.model.algorithm.llm.LLMClassifier
+    description: Few-shot LLM packing classifier
+    multiclass:  false
+    parameters:
+      static:
+        model_file:   mistral-7b-instruct-v0.2.Q4_K_M.gguf
+        model_repo:   TheBloke/Mistral-7B-Instruct-v0.2-GGUF
+        feature_names:
+          - entropy
+          - entropy_code_section
+          - entropy_section_with_ep
+        n_ctx:        4096
+        n_threads:    4
+        max_tokens:   64
+        temperature:  0.0
+        prompt_file:  few_shot_binary.txt
+        few_shot_count: 2
+        trace_outputs: false
+        trace_dir:    ~/.packing-box/cache/llm-traces
 
 Unsupervised:
   defaults:

--- a/src/lib/src/pbox/core/model/algorithm/llm.py
+++ b/src/lib/src/pbox/core/model/algorithm/llm.py
@@ -1,26 +1,56 @@
 # -*- coding: UTF-8 -*-
+import json
+import os
+import warnings
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
 import numpy as np
 from sklearn.base import BaseEstimator
 
-from pboxllm import LLMBackend, FeatureFormatter, PromptStrategy
+from pboxllm import LLMBackend, FeatureFormatter, PromptStrategy, proba_from_top_logprobs
 
 
 __all__ = ["LLMClassifier"]
 
 
 class LLMClassifier(BaseEstimator):
-    """LLM-based packing classifier using llama-cpp-python (zero-shot).
+    """LLM-based packing classifier using llama-cpp-python (in-context / zero-shot).
 
     This classifier mimics the sklearn fit/predict interface expected by pbox.
     It uses a local large language model (GGUF format, via llama-cpp-python)
     to determine whether a PE executable is packed, based on a human-readable
     text representation of selected binary features.
 
-    No gradient-based training occurs. ``fit`` loads the model into memory;
-    ``predict`` runs zero-shot inference for each sample.
+    No gradient-based training occurs. ``fit`` loads the model into memory and,
+    when ``few_shot_count`` is greater than zero, samples a fixed-size set of
+    labelled demos either from the feature matrix passed to ``fit`` or from an
+    external CSV / pbox dataset supplied via ``few_shot_examples_path``.
+
+    Few-shot scope and leakage (pbox ``Model.train``):
+        The final ``pipeline.fit`` call receives only the training split
+        (``_train.data`` / ``_train.target``). Few-shot demos are therefore built
+        exclusively from training rows. Metrics on the held-out test split do not
+        inject test labels or test feature rows into the prompt, which matches the
+        usual requirement that demonstration labels stay out of the evaluation
+        fold (standard in-context learning evaluation; see e.g. discussions of
+        train/test separation for prompt-based classifiers).
+
+        Caveats: (1) If you evaluate on training rows, a demo can coincide with
+        the target row by chance (sampling without replacement still leaves other
+        overlap risks); prefer reporting generalisation on ``_test``. (2) When
+        hyperparameters are chosen via ``GridSearchCV``, pbox fits the search on
+        the combined pre-split matrix; inner CV folds may mix partitions
+        differently from the outer train/test split — this is a broader tuning
+        protocol issue, not specific to the LLM.
+
+    Verbosity: set ``verbose`` > 0 to print the first-sample prompt and raw
+    generation (similar to a debug mode); default is silent.
     """
 
     classes_ = np.array([0, 1])
+    _few_shot_seed = 42
     _required_params = (
         "model_file",
         "model_repo",
@@ -40,6 +70,21 @@ class LLMClassifier(BaseEstimator):
         n_ctx=None,
         n_threads=None,
         max_tokens=None,
+        temperature=0.0,
+        top_p=1.0,
+        packed_label="packed",
+        not_packed_label="not-packed",
+        representation_style="flat",
+        few_shot_count=0,
+        few_shot_examples_path=None,
+        trace_outputs=False,
+        trace_dir=None,
+        parse_policy="p_packed_fallback",
+        on_backend_error="unknown",
+        verbose=0,
+        backend_factory=None,
+        formatter_factory=None,
+        strategy_factory=None,
     ):
         self.model_file = model_file
         self.model_repo = model_repo
@@ -48,6 +93,21 @@ class LLMClassifier(BaseEstimator):
         self.n_ctx = n_ctx
         self.n_threads = n_threads
         self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.top_p = top_p
+        self.packed_label = packed_label
+        self.not_packed_label = not_packed_label
+        self.representation_style = representation_style
+        self.few_shot_count = few_shot_count
+        self.few_shot_examples_path = few_shot_examples_path
+        self.trace_outputs = trace_outputs
+        self.trace_dir = trace_dir
+        self.parse_policy = parse_policy
+        self.on_backend_error = on_backend_error
+        self.verbose = int(verbose or 0)
+        self.backend_factory = backend_factory
+        self.formatter_factory = formatter_factory
+        self.strategy_factory = strategy_factory
 
     def __sklearn_is_fitted__(self):
         return hasattr(self, "backend_")
@@ -60,9 +120,21 @@ class LLMClassifier(BaseEstimator):
                 + ", ".join(missing)
                 + ". Configure them in algorithms.yml (LLM category)."
             )
-        self.backend_ = LLMBackend(self.model_file, self.model_repo, self.n_ctx, self.n_threads)
-        self.formatter_ = FeatureFormatter(self.feature_names)
-        self.strategy_ = PromptStrategy(self.prompt_file)
+        _backend_cls = self.backend_factory or LLMBackend
+        _formatter_cls = self.formatter_factory or FeatureFormatter
+        _strategy_cls = self.strategy_factory or PromptStrategy
+        self.backend_ = _backend_cls(self.model_file, self.model_repo, self.n_ctx, self.n_threads)
+        self.formatter_ = _formatter_cls(self.feature_names, representation_style=self.representation_style)
+        self.strategy_ = _strategy_cls(
+            self.prompt_file,
+            packed_label=self.packed_label,
+            not_packed_label=self.not_packed_label,
+            parse_policy=self.parse_policy,
+        )
+        self.strategy_.validate_template(self.few_shot_count)
+        self.few_shot_examples_ = self._build_few_shot_examples(X, y)
+        self._trace_run_id = None
+        self._trace_path = None
         self.backend_.load()
         return self
 
@@ -70,14 +142,355 @@ class LLMClassifier(BaseEstimator):
         if not hasattr(self, "backend_"):
             raise RuntimeError("LLMClassifier must be fitted before calling predict.")
         results = []
-        for i in range(len(X)):
-            row = X.iloc[i] if hasattr(X, "iloc") else X[i]
-            text = self.formatter_.format(row)
-            prompt = self.strategy_.build_prompt(text)
-            raw = self.backend_.generate(prompt, max_tokens=self.max_tokens)
-            results.append(self.strategy_.parse(raw))
+        with self._open_trace_file() as trace_file:
+            for i in range(len(X)):
+                row = X.iloc[i] if hasattr(X, "iloc") else X[i]
+                text = self.formatter_.format(row)
+                prompt = self.strategy_.build_prompt(text, few_shot_examples=self.few_shot_examples_)
+                prompt, trunc = self._truncate_prompt_to_context(prompt)
+                if self.verbose and i == 0:
+                    print("\n===== DEBUG PROMPT (first sample) =====\n")
+                    print(prompt)
+                    print("\n===== END DEBUG PROMPT =====\n")
+                backend_error = None
+                try:
+                    raw = self.backend_.generate(
+                        prompt,
+                        max_tokens=self.max_tokens,
+                        temperature=self.temperature,
+                        top_p=self.top_p,
+                    )
+                except Exception as exc:
+                    raw = ""
+                    backend_error = {"type": type(exc).__name__, "message": str(exc)}
+                if self.verbose and i == 0:
+                    print("\n===== DEBUG RAW LLM RESPONSE (first sample) =====\n")
+                    print(raw)
+                    print("\n===== DEBUG RAW LLM RESPONSE REPR (first sample) =====\n")
+                    print(repr(raw))
+                    print("\n===== END DEBUG RAW LLM RESPONSE =====\n")
+                parsed_meta = self.strategy_.parse_with_meta(raw)
+                if trunc:
+                    parsed_meta = {**parsed_meta, "prompt_truncated": True}
+                parsed = int(parsed_meta["label"])
+                if backend_error is not None and str(self.on_backend_error).lower() == "unknown":
+                    parsed = -1
+                    parsed_meta["reason"] = "backend_error"
+                self._trace_sample(
+                    method="predict",
+                    sample_index=i,
+                    prompt=prompt,
+                    raw_response=raw,
+                    parsed_label=int(parsed),
+                    parse_meta=parsed_meta,
+                    error=backend_error,
+                    trace_file=trace_file,
+                )
+                results.append(parsed)
         return np.array(results, dtype=int)
 
     def predict_proba(self, X):
-        preds = self.predict(X)
-        return np.vstack([1 - preds, preds]).T.astype(float)
+        if not hasattr(self, "backend_"):
+            raise RuntimeError("LLMClassifier must be fitted before calling predict_proba.")
+        probas = []
+        for i in range(len(X)):
+            out = None
+            raw = ""
+            backend_error = None
+            row = X.iloc[i] if hasattr(X, "iloc") else X[i]
+            text = self.formatter_.format(row)
+            prompt = self.strategy_.build_prompt(text, few_shot_examples=self.few_shot_examples_)
+            prompt, _trunc = self._truncate_prompt_to_context(prompt)
+            try:
+                out = self.backend_.generate_with_logprobs(
+                    prompt,
+                    max_tokens=self.max_tokens,
+                    temperature=self.temperature,
+                    top_p=self.top_p,
+                )
+                if self.verbose and i == 0:
+                    print("\n===== DEBUG RAW LLM RESPONSE PROBA PATH (first sample) =====\n")
+                    print(out.get("text", ""))
+                    print("\n===== DEBUG RAW LLM RESPONSE PROBA REPR (first sample) =====\n")
+                    print(repr(out.get("text", "")))
+                    print("\n===== END DEBUG RAW LLM RESPONSE PROBA PATH =====\n")
+                proba = proba_from_top_logprobs(out.get("top_logprobs"))
+                if proba is None:
+                    pred = self.strategy_.parse(out.get("text", ""))
+                    if pred == 1:
+                        proba = np.array([0.0, 1.0], dtype=float)
+                    elif pred == 0:
+                        proba = np.array([1.0, 0.0], dtype=float)
+                    else:
+                        proba = np.array([0.5, 0.5], dtype=float)
+            except ValueError:
+                # Some GGUF builds don't expose logprobs (logits_all=False).
+                # Fallback: generate plain text and map it to packedness.
+                try:
+                    raw = self.backend_.generate(
+                        prompt,
+                        max_tokens=self.max_tokens,
+                        temperature=self.temperature,
+                        top_p=self.top_p,
+                    )
+                except Exception as exc:
+                    raw = ""
+                    backend_error = {"type": type(exc).__name__, "message": str(exc)}
+                parsed_meta = self.strategy_.parse_with_meta(raw)
+                pred = parsed_meta["label"]
+                if backend_error is not None and str(self.on_backend_error).lower() == "unknown":
+                    pred = -1
+                if pred == 1:
+                    proba = np.array([0.0, 1.0], dtype=float)
+                elif pred == 0:
+                    proba = np.array([1.0, 0.0], dtype=float)
+                else:
+                    proba = np.array([0.5, 0.5], dtype=float)
+            except Exception as exc:
+                backend_error = {"type": type(exc).__name__, "message": str(exc)}
+                proba = np.array([0.5, 0.5], dtype=float)
+            probas.append(proba)
+        return np.vstack(probas)
+
+    def _build_few_shot_examples(self, X, y):
+        """Pick up to ``few_shot_count`` labelled rows for in-context demos.
+
+        When ``few_shot_examples_path`` is set, examples are drawn from that
+        external source (CSV file path or pbox dataset name) instead of the
+        training data. In both cases, balanced class sampling and shuffle apply.
+        """
+        if not self.few_shot_count:
+            return []
+        if self.few_shot_examples_path is not None:
+            X_pool, y_pool = self._load_examples_from_path(self.few_shot_examples_path)
+        else:
+            if y is None:
+                return []
+            X_pool = X
+            y_pool = np.asarray(y)
+        labels = np.asarray(y_pool)
+        if labels.size == 0:
+            return []
+        total = int(self.few_shot_count or 0)
+        if total <= 0:
+            return []
+        rng = np.random.RandomState(self._few_shot_seed)
+        packed_idx = np.where(labels == 1)[0]
+        not_packed_idx = np.where(labels == 0)[0]
+        selected_idx = []
+
+        if not_packed_idx.size == 0 and packed_idx.size == 0:
+            return []
+
+        if not_packed_idx.size == 0:
+            take = min(total, packed_idx.size)
+            selected_idx = rng.choice(packed_idx, size=take, replace=False).tolist()
+        elif packed_idx.size == 0:
+            take = min(total, not_packed_idx.size)
+            selected_idx = rng.choice(not_packed_idx, size=take, replace=False).tolist()
+        else:
+            n0_target = total // 2
+            n1_target = total - n0_target
+            n0 = min(n0_target, not_packed_idx.size)
+            n1 = min(n1_target, packed_idx.size)
+            if n0 + n1 < total:
+                need = total - n0 - n1
+                spare0 = not_packed_idx.size - n0
+                spare1 = packed_idx.size - n1
+                add0 = min(need, spare0)
+                n0 += add0
+                need -= add0
+                if need > 0:
+                    n1 += min(need, spare1)
+            pick0 = rng.choice(not_packed_idx, size=n0, replace=False) if n0 else np.array([], dtype=int)
+            pick1 = rng.choice(packed_idx, size=n1, replace=False) if n1 else np.array([], dtype=int)
+            selected_idx = np.concatenate([pick0, pick1]).tolist()
+            rng.shuffle(selected_idx)
+
+        examples = []
+        for idx in selected_idx:
+            row = X_pool.iloc[idx] if hasattr(X_pool, "iloc") else X_pool[idx]
+            examples.append({
+                "features_text": self.formatter_.format(row),
+                "label": int(labels[idx]),
+            })
+        return examples
+
+    def _load_examples_from_path(self, path_or_name):
+        """Return (X_pool, y_pool) from a CSV file path or pbox dataset name.
+
+        Resolution order:
+        1. Direct file path (absolute or relative).
+        2. ~/.packing-box/datasets/<name>/data.csv  (pbox dataset name).
+
+        The CSV must have a ``label`` column (0/1) and all columns listed in
+        ``self.feature_names``. pbox dataset CSVs use a semicolon separator.
+        """
+        import pandas as pd
+        df = self._resolve_examples_dataframe(path_or_name)
+        label_col = "label"
+        if label_col not in df.columns:
+            raise ValueError(
+                f"[LLMClassifier] few_shot_examples_path CSV must contain a "
+                f"'{label_col}' column. Found: {list(df.columns)}"
+            )
+        missing_features = [f for f in self.feature_names if f not in df.columns]
+        if missing_features:
+            raise ValueError(
+                f"[LLMClassifier] few_shot_examples_path CSV is missing feature "
+                f"columns: {missing_features}"
+            )
+        y_pool = df[label_col].to_numpy()
+        X_pool = df[list(self.feature_names)]
+        return X_pool, y_pool
+
+    def _resolve_examples_dataframe(self, path_or_name):
+        import pandas as pd
+        p = Path(path_or_name)
+        if p.exists():
+            sep = ";" if p.suffix == ".csv" and self._sniff_sep(p) == ";" else ","
+            return pd.read_csv(p, sep=sep)
+        pbox_candidate = (
+            Path(os.path.expanduser("~/.packing-box/datasets"))
+            / path_or_name
+            / "data.csv"
+        )
+        if pbox_candidate.exists():
+            return pd.read_csv(pbox_candidate, sep=";")
+        raise FileNotFoundError(
+            f"[LLMClassifier] few_shot_examples_path '{path_or_name}' not found "
+            f"as a file path or pbox dataset name "
+            f"(looked in ~/.packing-box/datasets/{path_or_name}/data.csv)."
+        )
+
+    @staticmethod
+    def _sniff_sep(path):
+        with open(path, encoding="utf-8", errors="replace") as f:
+            first_line = f.readline()
+        return ";" if first_line.count(";") > first_line.count(",") else ","
+
+    def _truncate_prompt_to_context(self, prompt):
+        """Trim prompt token-wise so prompt + generation fit in ``n_ctx``.
+
+        Reserves ``max_tokens`` for the completion plus a small margin. Keeps
+        the **suffix** of the prompt (the target sample usually appears at the
+        end). Falls back to a character heuristic if tokenization is unavailable.
+        """
+        self.backend_.load()
+        llm = self.backend_._llm
+        if llm is None or not prompt:
+            return prompt, False
+        n_ctx = int(getattr(self.backend_, "n_ctx", 2048) or 2048)
+        max_gen = int(self.max_tokens or 64)
+        reserve = 8
+        budget = max(32, n_ctx - max_gen - reserve)
+        enc = prompt.encode("utf-8")
+        tokens = None
+        for call in (
+            lambda: llm.tokenize(enc, add_bos=False),
+            lambda: llm.tokenize(enc),
+            lambda: llm.tokenize(enc, add_bos=True),
+        ):
+            try:
+                tokens = call()
+                break
+            except TypeError:
+                continue
+            except Exception:
+                continue
+        if tokens is None:
+            approx_chars = max(256, int(budget * 3.2))
+            if len(prompt) > approx_chars:
+                warnings.warn(
+                    f"[LLMClassifier] Prompt length ~{len(prompt)} chars may exceed "
+                    f"context (n_ctx={n_ctx}, max_tokens={max_gen}); truncated with "
+                    "a character fallback (tokenization unavailable).",
+                    UserWarning,
+                    stacklevel=3,
+                )
+                return prompt[-approx_chars:], True
+            return prompt, False
+        if len(tokens) <= budget:
+            return prompt, False
+        kept = tokens[-budget:]
+        try:
+            new_prompt = llm.detokenize(kept).decode("utf-8", errors="replace")
+        except Exception:
+            approx_chars = max(256, int(budget * 3.2))
+            new_prompt = prompt[-approx_chars:]
+        warnings.warn(
+            f"[LLMClassifier] Prompt truncated to fit context window: "
+            f"{len(tokens)} tokens reduced to {len(kept)} (n_ctx={n_ctx}, "
+            f"max_new_tokens={max_gen}).",
+            UserWarning,
+            stacklevel=3,
+        )
+        return new_prompt, True
+
+    @contextmanager
+    def _open_trace_file(self):
+        """Open the trace file once for the duration of a predict call.
+
+        Yields an open file handle when tracing is enabled, or None otherwise.
+        Writing is unbuffered at the OS level — each sample is written immediately
+        so a mid-run failure preserves all traces up to that point, without the
+        per-sample fsync overhead of the previous design.
+        """
+        if not self.trace_outputs:
+            yield None
+            return
+        path = self._resolve_trace_path()
+        with open(path, "a", encoding="utf-8") as f:
+            yield f
+
+    def _resolve_trace_path(self):
+        if self._trace_path is not None:
+            return self._trace_path
+        base_dir = self.trace_dir or os.path.expanduser("~/.packing-box/cache/llm-traces")
+        Path(base_dir).mkdir(parents=True, exist_ok=True)
+        if self._trace_run_id is None:
+            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            self._trace_run_id = f"{ts}-pid{os.getpid()}"
+        model_stub = str(self.model_file or "model").replace("/", "_")
+        algo_stub = str(self.representation_style or "flat").replace("/", "_")
+        prompt_stub = str(self.prompt_file or "prompt").replace("/", "_")
+        self._trace_path = str(Path(base_dir) / f"{self._trace_run_id}-{algo_stub}-{prompt_stub}-{model_stub}.jsonl")
+        return self._trace_path
+
+    def _trace_sample(
+        self,
+        method,
+        sample_index,
+        prompt,
+        raw_response,
+        parsed_label,
+        proba=None,
+        parse_meta=None,
+        error=None,
+        trace_file=None,
+    ):
+        if not self.trace_outputs or trace_file is None:
+            return
+        event = {
+            "timestamp_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "run_id": self._trace_run_id or "pending",
+            "method": method,
+            "sample_index": int(sample_index),
+            "model_file": self.model_file,
+            "model_repo": self.model_repo,
+            "prompt_file": self.prompt_file,
+            "representation_style": self.representation_style,
+            "n_ctx": self.n_ctx,
+            "n_threads": self.n_threads,
+            "max_tokens": self.max_tokens,
+            "temperature": getattr(self, "temperature", None),
+            "top_p": getattr(self, "top_p", None),
+            "parsed_label": int(parsed_label),
+            "parse_meta": parse_meta or {},
+            "raw_response": str(raw_response),
+            "proba": proba,
+            "error": error,
+            "prompt": prompt,
+            "trace_path": trace_file.name,
+        }
+        trace_file.write(json.dumps(event, ensure_ascii=False) + "\n")

--- a/src/lib/src/pboxllm/__init__.py
+++ b/src/lib/src/pboxllm/__init__.py
@@ -1,6 +1,15 @@
 # -*- coding: UTF-8 -*-
 from .backend import LLMBackend
 from .formatter import FeatureFormatter
+from .probability import proba_from_top_logprobs, logsumexp
 from .strategy import PromptStrategy
+from .types import FewShotExample
 
-__all__ = ["LLMBackend", "FeatureFormatter", "PromptStrategy"]
+__all__ = [
+    "LLMBackend",
+    "FeatureFormatter",
+    "FewShotExample",
+    "PromptStrategy",
+    "proba_from_top_logprobs",
+    "logsumexp",
+]

--- a/src/lib/src/pboxllm/backend.py
+++ b/src/lib/src/pboxllm/backend.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 __all__ = ["LLMBackend"]
 
-_MODEL_CACHE_DIR = Path(os.path.expanduser("~/.cache/pboxllm/models"))
+_MODEL_CACHE_DIR = Path(os.path.expanduser("~/.packing-box/cache/llm-models"))
 
 
 class LLMBackend:
@@ -57,7 +57,7 @@ class LLMBackend:
         from llama_cpp import Llama
         self._llm = Llama(model_path=str(self.model_path_), n_ctx=self.n_ctx, n_threads=self.n_threads, verbose=False)
 
-    def generate(self, prompt, max_tokens=64, temperature=0.0):
+    def generate(self, prompt, max_tokens=64, temperature=0.0, top_p=1.0):
         """Run inference and return the raw generated text.
 
         Parameters
@@ -78,8 +78,66 @@ class LLMBackend:
         """
         if self._llm is None:
             self.load()
-        result = self._llm(prompt, max_tokens=max_tokens, temperature=temperature, echo=False)
+        result = self._llm(
+            prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            echo=False,
+        )
         return result["choices"][0]["text"].strip()
+
+    def generate_with_logprobs(self, prompt, max_tokens=64, temperature=0.0, top_p=1.0, logprobs=10):
+        """Run inference and return generated text plus first-token logprobs when available.
+
+        Returns a dictionary with:
+        - ``text``: generated text (str)
+        - ``top_logprobs``: mapping token->logprob for the first generated token, or ``None``
+        """
+        if self._llm is None:
+            self.load()
+        try:
+            result = self._llm(
+                prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                echo=False,
+                logprobs=logprobs,
+            )
+        except (TypeError, ValueError) as exc:
+            # Some llama.cpp builds/models do not support logprobs unless
+            # logits_all was enabled at model creation time.
+            if isinstance(exc, ValueError) and "logprobs is not supported" not in str(exc):
+                raise
+            result = self._llm(
+                prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                echo=False,
+            )
+        choice = result["choices"][0]
+        top_logprobs = None
+        logprobs_data = choice.get("logprobs")
+        if isinstance(logprobs_data, dict):
+            top = logprobs_data.get("top_logprobs")
+            if isinstance(top, list) and len(top) > 0 and isinstance(top[0], dict):
+                top_logprobs = top[0]
+        return {"text": choice["text"].strip(), "top_logprobs": top_logprobs}
+
+    # ------------------------------------------------------------------
+    # Pickle support
+    # ------------------------------------------------------------------
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_llm"] = None
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._llm = None
 
     # ------------------------------------------------------------------
     # Model management

--- a/src/lib/src/pboxllm/formatter.py
+++ b/src/lib/src/pboxllm/formatter.py
@@ -1,7 +1,14 @@
 # -*- coding: UTF-8 -*-
-
+import functools
 
 __all__ = ["FeatureFormatter"]
+
+_BULLET_HEADERS = {
+    "compact_pe_structural": "COMPACT_PE_BUNDLE",
+    "strings_summary": "STRINGS_SUMMARY",
+}
+
+_VALID_STYLES = {"flat", "structured_semantic_pe", "compact_pe_structural", "strings_summary"}
 
 
 def _load_descriptions():
@@ -36,10 +43,24 @@ class FeatureFormatter:
         Loaded mapping of feature name → description (populated on first ``format`` call).
     """
 
-    def __init__(self, feature_names):
+    def __init__(self, feature_names, representation_style="flat"):
+        if representation_style not in _VALID_STYLES:
+            raise ValueError(
+                f"[FeatureFormatter] Unknown representation_style '{representation_style}'. "
+                f"Valid styles: {sorted(_VALID_STYLES)}"
+            )
         self.feature_names = feature_names
+        self.representation_style = representation_style
+        self._feature_index = {name: idx for idx, name in enumerate(feature_names)}
         self._descriptions = {}
         self._descriptions_loaded = False
+        if representation_style in _BULLET_HEADERS:
+            _header = _BULLET_HEADERS[representation_style]
+            self._render = functools.partial(self._format_bullet_list, header=_header)
+        elif representation_style == "structured_semantic_pe":
+            self._render = self._format_structured_semantic_pe
+        else:
+            self._render = self._format_flat
 
     def format(self, row):
         """Format a single feature row as a text block.
@@ -57,15 +78,89 @@ class FeatureFormatter:
         if not self._descriptions_loaded:
             self._descriptions = _load_descriptions()
             self._descriptions_loaded = True
+        return self._render(row)
 
+    def _format_flat(self, row):
         lines = []
         for name in self.feature_names:
             label = self._descriptions.get(name, name.replace("_", " "))
-            try:
-                value = row[name]
-            except (KeyError, IndexError):
-                value = "N/A"
-            if isinstance(value, float) and not isinstance(value, bool):
-                value = f"{value:.4f}"
-            lines.append(f"{label}: {value}")
+            lines.append(f"{label}: {self._format_value(self._get_row_value(row, name))}")
         return "\n".join(lines)
+
+    def _format_structured_semantic_pe(self, row):
+        groups = {
+            "entropy_and_entrypoint": [],
+            "sections_and_structure": [],
+            "imports_and_apis": [],
+            "strings_and_content": [],
+            "other_indicators": [],
+        }
+        for name in self.feature_names:
+            item = (self._descriptions.get(name, name.replace("_", " ")), self._format_value(self._get_row_value(row, name)))
+            n = name.lower()
+            if "entropy" in n or "ep" in n or "entry" in n:
+                groups["entropy_and_entrypoint"].append(item)
+            elif "section" in n or "size_" in n or "headers" in n or "image" in n:
+                groups["sections_and_structure"].append(item)
+            elif "import" in n or "api" in n or "dll" in n or "iat" in n or "idt" in n:
+                groups["imports_and_apis"].append(item)
+            elif "string" in n or "url" in n:
+                groups["strings_and_content"].append(item)
+            else:
+                groups["other_indicators"].append(item)
+        lines = ["PE_STATIC_REPORT {"]
+        for section, pairs in groups.items():
+            if not pairs:
+                continue
+            lines.append(f"  {section}:")
+            for label, value in pairs:
+                lines.append(f"    - {label}: {value}")
+        lines.append("}")
+        return "\n".join(lines)
+
+    def _format_bullet_list(self, row, header):
+        lines = [header]
+        for name in self.feature_names:
+            label = self._descriptions.get(name, name.replace("_", " "))
+            value = self._format_value(self._get_row_value(row, name))
+            lines.append(f"- {label}: {value}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _safe_index(row, idx):
+        try:
+            if hasattr(row, "iloc"):
+                return row.iloc[idx]
+            return row[idx]
+        except Exception:
+            return "N/A"
+
+    def _get_row_value(self, row, name):
+        try:
+            return row[name]
+        except (KeyError, IndexError):
+            idx = self._feature_index.get(name)
+            if idx is None:
+                return "N/A"
+            return self._safe_index(row, idx)
+        except TypeError:
+            idx = self._feature_index.get(name)
+            if idx is None:
+                return "N/A"
+            return self._safe_index(row, idx)
+
+    @staticmethod
+    def _format_value(value):
+        if isinstance(value, float) and not isinstance(value, bool):
+            return f"{value:.4f}"
+        if isinstance(value, (list, tuple, set)):
+            seq = list(value)
+            preview = ", ".join(map(str, seq[:8]))
+            suffix = " ..." if len(seq) > 8 else ""
+            return f"[{preview}{suffix}] (n={len(seq)})"
+        if isinstance(value, dict):
+            keys = list(value.keys())
+            preview = ", ".join(map(str, keys[:8]))
+            suffix = " ..." if len(keys) > 8 else ""
+            return f"{{keys: {preview}{suffix}}} (n={len(keys)})"
+        return value

--- a/src/lib/src/pboxllm/probability.py
+++ b/src/lib/src/pboxllm/probability.py
@@ -1,0 +1,33 @@
+# -*- coding: UTF-8 -*-
+import numpy as np
+
+
+__all__ = ["proba_from_top_logprobs", "logsumexp"]
+
+_PACKED_TOKENS = ("packed", " packed", "yes", " yes", "true", " true", "1", " 1")
+_NOT_PACKED_TOKENS = ("not", " not", "no", " no", "false", " false", "0", " 0", "unpacked", " unpacked")
+
+
+def logsumexp(values):
+    arr = np.asarray(values, dtype=float)
+    m = np.max(arr)
+    return float(m + np.log(np.sum(np.exp(arr - m))))
+
+
+def proba_from_top_logprobs(top_logprobs):
+    """Convert first-token top_logprobs to binary probabilities.
+
+    Returns None when token evidence is insufficient.
+    Output format is [P(not-packed), P(packed)].
+    """
+    if not isinstance(top_logprobs, dict) or len(top_logprobs) == 0:
+        return None
+    packed_scores = [v for k, v in top_logprobs.items() if k in _PACKED_TOKENS]
+    not_packed_scores = [v for k, v in top_logprobs.items() if k in _NOT_PACKED_TOKENS]
+    if not packed_scores or not not_packed_scores:
+        return None
+    l_packed = logsumexp(packed_scores)
+    l_not_packed = logsumexp(not_packed_scores)
+    den = logsumexp([l_not_packed, l_packed])
+    p_packed = float(np.exp(l_packed - den))
+    return np.array([1.0 - p_packed, p_packed], dtype=float)

--- a/src/lib/src/pboxllm/prompts/few_shot_binary.txt
+++ b/src/lib/src/pboxllm/prompts/few_shot_binary.txt
@@ -1,20 +1,8 @@
 You are a malware analysis expert specializing in detecting packed executables.
 
 A packed executable has usually been compressed or encrypted by a packer.
-
-Here are examples:
-- Example A features:
-  entropy: 7.9000
-  entropy_code_section: 7.4000
-  entropy_section_with_ep: 7.6000
-  Label: packed
-- Example B features:
-  entropy: 5.1000
-  entropy_code_section: 4.7000
-  entropy_section_with_ep: 4.9000
-  Label: not-packed
-
-Now classify the following sample using the same logic:
+{few_shot_examples}
+Now classify the following sample:
 
 {features}
 

--- a/src/lib/src/pboxllm/strategy.py
+++ b/src/lib/src/pboxllm/strategy.py
@@ -40,17 +40,28 @@ class PromptStrategy:
         Contents of the loaded prompt file (populated on first use).
     """
 
-    def __init__(self, prompt_file, prompt_dir=_PROMPT_CACHE_DIR, default_prompt_dir=_DEFAULT_PROMPT_DIR):
+    def __init__(
+        self,
+        prompt_file,
+        prompt_dir=_PROMPT_CACHE_DIR,
+        default_prompt_dir=_DEFAULT_PROMPT_DIR,
+        packed_label="packed",
+        not_packed_label="not-packed",
+        parse_policy="p_packed_fallback",
+    ):
         self.prompt_file = prompt_file
         self.prompt_dir = prompt_dir
         self.default_prompt_dir = default_prompt_dir
+        self.packed_label = str(packed_label).strip().lower()
+        self.not_packed_label = str(not_packed_label).strip().lower()
+        self.parse_policy = str(parse_policy or "p_packed_fallback").strip().lower()
         self._template = None
 
     # ------------------------------------------------------------------
     # Public interface
     # ------------------------------------------------------------------
 
-    def build_prompt(self, features_text):
+    def build_prompt(self, features_text, few_shot_examples=None):
         """Fill the prompt template with the formatted feature block.
 
         Parameters
@@ -63,9 +74,15 @@ class PromptStrategy:
         str
             The full prompt ready to be sent to the LLM backend.
         """
-        return self._load_template().format(features=features_text)
+        return self._render_template(
+            features_text=features_text,
+            few_shot_examples=few_shot_examples or [],
+        )
 
     def parse(self, response):
+        return self.parse_with_meta(response)["label"]
+
+    def parse_with_meta(self, response):
         """Parse the LLM raw response into a binary label.
 
         Looks for keywords indicating packed (1) or not-packed (0). 
@@ -82,11 +99,96 @@ class PromptStrategy:
         int
             ``1`` if packed, ``0`` if not-packed, ``-1`` if uncertain/unrecognised.
         """
+        response = str(response or "")
+        resp_lower = response.lower().strip()
+        meta = {
+            "label": -1,
+            "reason": "unparsed",
+            "decision": None,
+            "decision_valid": False,
+            "p_packed": None,
+            "used_fallback": False,
+        }
+        if not resp_lower:
+            meta["reason"] = "empty_response"
+            return meta
+
+        d = re.search(r"\bdecision\s*:\s*([A-Za-z]+)\b", response, re.IGNORECASE)
+        if d:
+            decision = d.group(1).strip().upper()
+            meta["decision"] = decision
+            if decision in ("YES", "NO"):
+                meta["decision_valid"] = True
+
+        # 1) Preferred path: parse explicit "P_PACKED: <p>" outputs.
+        # This is required for prompts coming from the experiments pipeline
+        # (e.g., zero_shot/verbalized_probability.txt).
+        m = re.search(r"\bP_PACKED\s*:\s*([0-9]*\.?[0-9]+)\b", resp_lower, re.IGNORECASE)
+        if m:
+            try:
+                p = float(m.group(1))
+                meta["p_packed"] = p
+                if self.parse_policy == "strict_unknown" and meta["decision"] is not None and not meta["decision_valid"]:
+                    meta["reason"] = "invalid_decision_token"
+                    return meta
+                if p >= 0.5:
+                    meta["label"] = 1
+                    meta["reason"] = "p_packed_threshold"
+                    if meta["decision"] == "NO":
+                        meta["used_fallback"] = True
+                    return meta
+                if p < 0.5:
+                    meta["label"] = 0
+                    meta["reason"] = "p_packed_threshold"
+                    if meta["decision"] == "YES":
+                        meta["used_fallback"] = True
+                    return meta
+            except ValueError:
+                pass
+
+        if self.parse_policy == "strict_unknown" and meta["decision"] is not None and not meta["decision_valid"]:
+            meta["reason"] = "invalid_decision_token"
+            return meta
+
+        # 2) Strict token match first (best for single-token prompts).
+        token = resp_lower.split()
+        token0 = token[0].strip().lower() if token else ""
+        if token0:
+            if token0 == self.not_packed_label:
+                meta["label"] = 0
+                meta["reason"] = "exact_token_not_packed"
+                return meta
+            if token0 == self.packed_label:
+                meta["label"] = 1
+                meta["reason"] = "exact_token_packed"
+                return meta
+
+        # 3) Fallback keyword search.
+        # Note: keep _NO before _YES so "no"/"false"/"0" map to not-packed,
+        # but ambiguous outputs are still handled by the exact-token path above.
         if _NO.search(response):
-            return 0
+            meta["label"] = 0
+            meta["reason"] = "keyword_no"
+            return meta
         if _YES.search(response):
-            return 1
-        return -1
+            meta["label"] = 1
+            meta["reason"] = "keyword_yes"
+            return meta
+        return meta
+
+    def validate_template(self, few_shot_count):
+        """Raise ValueError if the template is incompatible with the few-shot config.
+
+        Call this from ``LLMClassifier.fit`` so template/mode mismatches surface
+        before any inference runs.
+        """
+        template = self._load_template()
+        has_ph = "{few_shot_examples}" in template
+        if few_shot_count and not has_ph:
+            raise ValueError(
+                f"[pboxllm] few_shot_count={few_shot_count} but template "
+                f"'{self.prompt_file}' has no {{few_shot_examples}} placeholder."
+            )
 
     # ------------------------------------------------------------------
     # Template loading
@@ -104,6 +206,66 @@ class PromptStrategy:
             )
         self._template = path.read_text(encoding="utf-8")
         return self._template
+
+    def _render_template(self, features_text, few_shot_examples):
+        template = self._load_template()
+        mapping = {"features": features_text}
+        has_ph = "{few_shot_examples}" in template
+        if has_ph:
+            mapping["few_shot_examples"] = self._format_few_shot_examples(few_shot_examples)
+            return template.format(**mapping)
+        if few_shot_examples:
+            raise ValueError(
+                f"[pboxllm] few_shot_count > 0 but template '{self.prompt_file}' "
+                "has no {few_shot_examples} placeholder. "
+                "Add the placeholder to the template where you want demo examples to appear, "
+                "or call validate_template() during fit to catch this early."
+            )
+        return template.format(**mapping)
+
+    def _few_shot_body(self, few_shot_examples):
+        """Return the numbered example block only (no surrounding English header)."""
+        if not few_shot_examples:
+            return ""
+        lines = []
+        for i, example in enumerate(few_shot_examples, start=1):
+            feat_txt = example.get("features_text", "")
+            if not feat_txt:
+                raise ValueError(
+                    f"[pboxllm] FewShotExample at index {i - 1} has an empty "
+                    "'features_text'. This would inject a blank example into the prompt."
+                )
+            label = self._normalize_label(example.get("label", "unknown"))
+            lines.append(
+                "Example {i}:\nFeatures:\n{features}\nLabel: {label}".format(
+                    i=i,
+                    features=feat_txt,
+                    label=label,
+                )
+            )
+        return "\n\n".join(lines)
+
+    def _format_few_shot_examples(self, few_shot_examples):
+        body = self._few_shot_body(few_shot_examples)
+        if not body:
+            return ""
+        return "\nHere are some examples to guide your reasoning:\n\n{}\n".format(body)
+
+    def _normalize_label(self, label):
+        """Map training / sklearn-style labels to the prompt wording configured on this instance.
+
+        Uses ``self.packed_label`` / ``self.not_packed_label`` so that demo
+        examples in few-shot prompts use the same label vocabulary as the
+        response instruction (critical for neutral-label configs such as A/B).
+        """
+        if label in [1, "1", True]:
+            return self.packed_label
+        if label in [0, "0", False]:
+            return self.not_packed_label
+        text = str(label).strip().lower()
+        if text == self.packed_label or text == self.not_packed_label:
+            return text
+        return "unknown"
 
     def _bootstrap_default_prompt(self):
         self.prompt_dir.mkdir(parents=True, exist_ok=True)

--- a/src/lib/src/pboxllm/types.py
+++ b/src/lib/src/pboxllm/types.py
@@ -1,0 +1,7 @@
+# -*- coding: UTF-8 -*-
+from typing import TypedDict
+
+
+class FewShotExample(TypedDict):
+    features_text: str
+    label: int


### PR DESCRIPTION
## Summary

- Add few-shot support to `LLMClassifier`: new `few_shot_count` parameter samples labelled demos from the training split and injects them into the prompt via a `{few_shot_examples}` placeholder.
- Add `Mistral-LLM-FewShot` algorithm in `algorithms.yml`
- Extend `PromptStrategy.parse` into `parse_with_meta` returning metadata (label, reason, p_packed, decision, fallback flag), old `parse` preserved as wrapper.
- Add `generate_with_logprobs` to `LLMBackend` for first-token log-probability extraction with fallback for llama.cpp builds without logprobs.
- Add `FeatureFormatter` representation styles, `probability.py` utility, `types.py` shared types.
- Add trace/debug output support (`trace_outputs`, `trace_dir` params).
- Fix model cache dir path (`~/.packing-box/cache/llm-models`).

All modifications confined to `pboxllm/`